### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ And from the output:
 If you see `mingw32`, that means you're using a RubyInstaller build
 (MinGW based).
 
+Once you have installed DevKit into the version of ruby that you wish to build against,
+the "gem compile" command might fail with the error message,
+
+    ERROR:  While executing gem ... (Gem::Installer::ExtensionBuildError)
+    ERROR: Failed to build gem native extensions.
+    
+The solution is to ensure your path is enhanced with the DevKit tools.
+Execute the following from your DevKit home directory:
+
+    devkitvars.bat
+    
+Re-run "gem compile gemname-0.0.0.gem --prune" and it should be successful.
+
 ## Differences with rake-compiler
 
 [rake-compiler](https://github.com/luislavena/rake-compiler) has provided to


### PR DESCRIPTION
With windows, ruby 2.0.0, and the DevKit, the "gem compile" command does not automatically enhance the PATH to use DevKit tools.
The PATH enhancement can be made with a simple batch file that comes with DevKit.
The easiest solution to this error is to simply call out to it in the docs and provide the name of the batch file to use.
